### PR TITLE
Version Constraint fix: Removed Filament v3 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "filament/filament": "^3|^4.0",
+        "filament/filament": "^4.0",
         "spatie/laravel-package-tools": "^1.15.0"
     },
     "require-dev": {


### PR DESCRIPTION
- Filament v3 is only supported by up to v4 of this package
- v5 of this package only supports Filament v4.
- Fixes #116